### PR TITLE
feat: gh pages website with documentation

### DIFF
--- a/.github/workflows/results-to-pages.yml
+++ b/.github/workflows/results-to-pages.yml
@@ -1,4 +1,4 @@
-name: Deploy validation results to GH Pages
+name: Deploy documentation and validation results to GitHub Pages
 
 on:
   # Runs on pushes targeting the default branch
@@ -33,18 +33,23 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Prepare content
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Build documentation
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+      - name: Add validation data
         run: |
-          rm -rf gh-pages
-          mkdir gh-pages
-          cp index.json gh-pages/
-          cp -r results gh-pages/
-          cp -r avatars gh-pages/
-          cp gh-pages-index.html gh-pages/index.html
+          cp index.json _site/
+          cp -r results _site/
+          cp -r avatars _site/
+          cp gh-pages-index.html _site/index.html
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          path: gh-pages
+          path: _site
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ If you use _standard-GEM_ or this validation pipeline in your scientific work, p
 > Anton, M., et al (2023). _standard-GEM: standardization of open-source genome-scale metabolic models_. bioRxiv, 2023-03 [doi:10.1101/2023.03.21.512712](https://www.biorxiv.org/content/10.1101/2023.03.21.512712)
 
 
-### Using the validation data
+### Documentation and validation data
 
-The generated JSON files and avatars are published through GitHub Pages so that they can be consumed by other services. They are available at:
+Documentation source lives in [`docs/index.md`](docs/index.md) and is published as a single page at [`/docs/`](https://metabolicatlas.github.io/standard-GEM-validation/docs). Each JSON file contains metadata about the repository, release history, and test results for the model.
+
+The generated JSON files, and avatars are published through GitHub Pages so that they can be read by people and consumed by other services:
 
 ```
 https://metabolicatlas.github.io/standard-GEM-validation/index.json
@@ -19,6 +21,4 @@ https://metabolicatlas.github.io/standard-GEM-validation/results/<model>.json
 https://metabolicatlas.github.io/standard-GEM-validation/avatars/<avatar>.png
 ```
 
-Each JSON file contains metadata about the repository, release history, and test results for the model.
-
-A minimal redirect page [`gh-pages-index.html`](gh-pages-index.html) points to the interactive overview on [metabolicatlas.org](https://metabolicatlas.org/gem/standard-gems). That site uses the data published from this repository to display up‑to‑date information about standard‑GEM models.
+The interactive overview on [metabolicatlas.org](https://metabolicatlas.org/gems/standard-gems) uses the data published from this repository to display up-to-date information about standard-GEM models.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,23 @@
+title: standard-GEM validation
+description: Documentation for the standard-GEM validation pipeline and published result data.
+url: https://metabolicatlas.github.io
+baseurl: /standard-GEM-validation
+markdown: kramdown
+remote_theme: just-the-docs/just-the-docs
+plugins:
+  - jekyll-remote-theme
+
+search_enabled: true
+heading_anchors: true
+aux_links:
+  "GitHub repository":
+    - "https://github.com/MetabolicAtlas/standard-GEM-validation"
+
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: default
+
+exclude:
+  - README.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,214 @@
+---
+title: Documentation
+description: Documentation for the standard-GEM validation framework, published data, and GitHub Pages deployment.
+permalink: /docs/
+---
+
+# standard-GEM validation
+
+{: .lead }
+This repository discovers genome-scale metabolic model repositories that follow the standard-GEM convention, runs a compact validation suite, and publishes the results through GitHub Pages.
+
+The documentation is a single page at:
+
+```text
+https://metabolicatlas.github.io/standard-GEM-validation/docs/
+```
+
+## Public endpoints
+
+The GitHub Pages site publishes both this documentation and the generated validation artifacts:
+
+```text
+https://metabolicatlas.github.io/standard-GEM-validation/docs/
+https://metabolicatlas.github.io/standard-GEM-validation/index.json
+https://metabolicatlas.github.io/standard-GEM-validation/results/<model>.json
+https://metabolicatlas.github.io/standard-GEM-validation/avatars/<avatar>.png
+```
+
+The interactive standard-GEM overview on metabolicatlas.org consumes these data files:
+
+[https://metabolicatlas.org/gems/standard-gems](https://metabolicatlas.org/gems/standard-gems)
+
+## Validation framework
+
+The validation framework is intentionally small. The orchestration lives in `runner.py`; individual checks live as plain Python functions in the `tests/` package.
+
+### Repository discovery
+
+`runner.matrix()` refreshes `index.json` with repositories tagged `standard-gem`:
+
+| Provider | Discovery source |
+| --- | --- |
+| GitHub | GraphQL repository search for `topic:standard-gem`, including forks |
+| GitLab | GraphQL project search for the `standard-gem` topic |
+
+The GitHub repository for the standard itself is excluded from the discovered model list. Existing repositories in `index.json` are retained and merged with newly discovered repositories.
+
+### Validation target selection
+
+For each repository, `runner.validate(name_with_owner, provider)` writes one result file under `results/`.
+
+The runner:
+
+1. Collects repository metadata such as owner, commit count, contributor count, latest commit date, and owner avatar.
+2. Looks up the latest standard-GEM release from `MetabolicAtlas/standard-GEM`.
+3. Finds the first model release that has not already been stored in the local result file.
+4. Falls back to the `main` branch when there is no new release to validate.
+5. Downloads available model files from the repository `model/` directory.
+6. Runs all discovered test functions and writes the result JSON.
+
+The model file base name is the repository name. The runner looks for these formats:
+
+```text
+model/<repository-name>.yml
+model/<repository-name>.xml
+model/<repository-name>.mat
+model/<repository-name>.json
+```
+
+### Standard check
+
+For each validated tag or branch, the runner compares the repository `.standard-GEM.md` file with the selected standard-GEM version. Markdown checkbox states are ignored, so `[ ]` and `[x]` do not affect the comparison.
+
+The result is stored under `standard-GEM` as a boolean keyed by standard version.
+
+### Test discovery
+
+`runner.discover_tests()` imports every Python module in `tests/` and collects public functions. Any function whose name does not start with `_` is treated as a validation check.
+
+Each test function receives the model name and returns:
+
+```text
+test_module, description, module_version, status, errors
+```
+
+`runner.result_json_string()` converts that tuple into the JSON shape used in result files. Error output is capped to 300 characters.
+
+### Current checks
+
+| Result key | Source | What it checks | Status value |
+| --- | --- | --- | --- |
+| `cobrapy-load-yaml` | `tests/cobra.py` | The YAML model can be loaded by cobrapy. | Boolean |
+| `cobrapy-load-sbml` | `tests/cobra.py` | The SBML model can be loaded by cobrapy. | Boolean |
+| `cobrapy-load-matlab` | `tests/cobra.py` | The Matlab model can be loaded by cobrapy. | Boolean |
+| `cobrapy-load-json` | `tests/cobra.py` | The JSON model can be loaded by cobrapy. | Boolean |
+| `cobrapy-validate-sbml` | `tests/cobra.py` | The SBML model has no fatal, error, schema, or COBRA errors according to cobrapy. | Boolean |
+| `yamllint` | `tests/yaml.py` | The YAML model passes yamllint with default rules and disabled line length checks. | Boolean |
+| `memote-score` | `tests/memote.py` | A focused Memote suite for annotation, consistency, coverage, duplicate, transport, and balance checks. | Numeric score or `false` |
+
+Missing files are reported as failed checks with an explanatory error string.
+
+## Published data
+
+The GitHub Pages deployment publishes machine-readable validation data alongside this documentation.
+
+### Repository index
+
+`index.json` lists known standard-GEM repositories grouped by provider:
+
+```json
+{
+  "github": [
+    "SysBioChalmers/yeast-GEM"
+  ],
+  "gitlab": [
+    "group/project"
+  ]
+}
+```
+
+Public URL:
+
+```text
+https://metabolicatlas.github.io/standard-GEM-validation/index.json
+```
+
+### Result files
+
+Each model has a result file under `results/`:
+
+```text
+https://metabolicatlas.github.io/standard-GEM-validation/results/<model>.json
+```
+
+At the top level, each file is keyed by model name:
+
+```json
+{
+  "yeast-GEM": {
+    "metadata": {},
+    "releases": []
+  }
+}
+```
+
+`metadata` contains:
+
+| Field | Meaning |
+| --- | --- |
+| `owner` | Repository owner, organization, or namespace. |
+| `avatar` | Cached avatar filename under `avatars/`, when available. |
+| `commits` | Commit count reported by the provider. |
+| `contributors` | Contributor count reported by the provider. |
+| `latest_commit_date` | Latest default-branch commit timestamp reported by the provider. |
+
+`releases` is an ordered list of validated tags or branches. Each entry stores the standard-GEM comparison and the collected test results:
+
+```json
+[
+  {
+    "v1.0.0": {
+      "standard-GEM": [
+        { "0.5": true },
+        {
+          "test_results": {
+            "yamllint": {
+              "description": "Check if the model in YAML format is formatted correctly.",
+              "version": "1.37.1",
+              "status": true,
+              "errors": []
+            }
+          }
+        }
+      ]
+    }
+  }
+]
+```
+
+### Avatars
+
+Repository owner avatars are cached in `avatars/` and published as static files:
+
+```text
+https://metabolicatlas.github.io/standard-GEM-validation/avatars/<avatar>.png
+```
+
+The avatar filename is referenced by each model result file under `metadata.avatar`.
+
+## Deployment
+
+GitHub Pages is deployed by `.github/workflows/results-to-pages.yml`.
+
+The workflow runs when changes land on `main`, when triggered manually, and on its daily schedule. It builds the Markdown documentation in `docs/` with Jekyll, then copies the generated validation artifacts into the same site artifact.
+
+### Site source
+
+Documentation source lives in `docs/index.md`. It renders to `/docs/` through its front matter permalink. The page uses a minimal local layout in `docs/_layouts/default.html` and styling from `docs/assets/css/style.css`.
+
+No external theme is required.
+
+### Deployment artifact
+
+The deployed artifact contains:
+
+```text
+/
+  docs/
+  index.json
+  results/
+  avatars/
+```
+
+The documentation is available under `/docs/`, while validation data is available from the same public JSON and avatar paths.


### PR DESCRIPTION
This PR adds a documentation webpage based on the contents of the `/docs` folder.